### PR TITLE
Fix parse error if SRC column is "<no location info>"

### DIFF
--- a/ProfFile.hs
+++ b/ProfFile.hs
@@ -64,27 +64,37 @@ parseLine format s =
     IncludesSources ->
       case words s of
         (costCentre:module_:rest) | (no:entries:indTime:indAlloc:inhTime:inhAlloc:other) <- dropSRC rest ->
-              parse' costCentre module_ no entries indTime indAlloc inhTime inhAlloc other
+          parse' costCentre module_ no entries indTime indAlloc inhTime inhAlloc other
         _ -> Left $ "Malformed .prof file line:\n" ++ s
   where
-    -- XXX: The SRC field can contain arbitrary characters (from the subdirectory name)!
+    -- XXX: The SRC field can contain arbitrary characters (from the
+    --      subdirectory name)!
     --
     -- As a heuristic, assume SRC spans until the last word which:
     --
-    -- * Ends with '>' (for special values emitted by GHC like "<no location info>")
+    -- * Ends with '>'
+    --   (for special values emitted by GHC like "<no location info>")
+    --
     -- or
+    --
     -- * Contains a colon eventually followed by another colon or a minus
-    --   (to identify the source span, e.g. ":69:55-64" or ":(36,1)-(38,30)", or maybe for a single character ":30:3")
+    --   (to identify the source span, e.g. ":69:55-64" or ":(36,1)-(38,30)",
+    --    or maybe for a single character ":30:3")
     --
     -- If there is no such word, assume SRC is just one word.
     --
     -- This heuristic will break if:
     --
-    -- * In the future, columns to the right of SRC can match the above condition (currently, they're all numeric)
-    -- or
-    -- * GHC doesn't add a source span formatted as assumed above, and the SRC contains spaces
+    -- * In the future, columns to the right of SRC can match the above
+    --   condition (currently, they're all numeric)
     --
-    -- The implementation is not very efficient, but I suppose this is not performance-critical.
+    -- or
+    --
+    -- * GHC doesn't add a source span formatted as assumed above, and the
+    --   SRC contains spaces
+    --
+    -- The implementation is not very efficient, but I suppose this is not
+    -- performance-critical.
     dropSRC (_:rest) = reverse . takeWhile (not . isPossibleEndOfSRC) . reverse $ rest
     dropSRC [] = []
 

--- a/ProfFile.hs
+++ b/ProfFile.hs
@@ -14,7 +14,7 @@ module ProfFile
 
 import           Control.Arrow (second, left)
 import           Data.Char (isSpace)
-import           Data.List (isPrefixOf, isSubsequenceOf)
+import           Data.List (isPrefixOf)
 import           Text.Read (readEither)
 import           Control.Monad (unless)
 import           Control.Applicative
@@ -98,9 +98,10 @@ parseLine format s =
     dropSRC (_:rest) = reverse . takeWhile (not . isPossibleEndOfSRC) . reverse $ rest
     dropSRC [] = []
 
-    isPossibleEndOfSRC w =    "::" `isSubsequenceOf` w
-                           || ":-" `isSubsequenceOf` w
-                           || last w == '>'
+    isPossibleEndOfSRC w = last w == '>'
+                           || case break (==':') w of
+                                (_, _:rest) -> any (`elem` ":-") rest
+                                _ -> False
 
     parse' costCentre module_ no entries indTime indAlloc inhTime inhAlloc other = do
       pNo <- readEither' no


### PR DESCRIPTION
Hello,

if the (recently added) SRC column of a .prof file has the value `<no location info>`, we currently get the error `ghc-prof-flamegraph: Prelude.read: no parse`.

First, to locate the error, I added line numbers and the value which didn't parse to the error messages. While fixing the actual issue (the space in `<no location info>`), I noticed a bigger problem: The SRC column can apparently contain arbitrary characters without escaping. Thus, it's impossible to find its end, at least without knowing exactly what the rest of the line has to look like. I implemented a simple heuristic for now; see the comment in the source.