### PR TITLE
Automatically invoke flamegraph.pl and bundle it together with executable

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "FlameGraph"]
+        path = FlameGraph
+        url = https://github.com/brendangregg/FlameGraph.git

--- a/README.md
+++ b/README.md
@@ -12,15 +12,23 @@ understandable by the
 
 ## Usage
 
-First convert a `.prof` file into the flame graph format using
-`ghc-prof-flamegraph`:
+First convert a `.prof` file into the flame graph svg:
 
-    $ cat ~/src/packdeps/packdeps.prof | ghc-prof-flamegraph > packdeps.prof.folded
+    $ cat ~/src/packdeps/packdeps.prof | ghc-prof-flamegraph > packdeps.prof.svg
 
-Then you can use the file to produce an svg image, using the
-[`flamegraph.pl`](https://github.com/brendangregg/FlameGraph) script:
+Or, alternatively, just pass the `.prof` file as an argument. The tool will
+then create corresponing `.svg` file:
 
-    $ cat packdeps.prof.folded | ~/src/FlameGraph/flamegraph.pl > packdeps.prof.svg
+    $ ghc-prof-flamegraph ~/src/packdeps/packdeps.prof
+    Output written to ~/src/packdeps/packdeps.svg
+
+The previous command will produce `~/src/packdeps/packdeps.svg` file.
+
+You can customize the behavior of the underlying `flamegraph.pl` by passing
+options via `–framegraph-option`. For example, you can customize the title:
+
+    $ ghc-prof-flamegraph ~/src/packdeps/packdeps.prof '--flamegraph-option=--title=Package dependencies'
+    Output written to ~/src/packdeps/packdeps.svg
 
 You can also generate a flamegraph using the allocation measurements,
 using the `--alloc` flag.

--- a/ghc-prof-flamegraph.cabal
+++ b/ghc-prof-flamegraph.cabal
@@ -29,20 +29,19 @@ description:
   bytes allocated using @--bytes@. In order to use @--bytes@ or @--ticks@ flag one
   have to run program with @+RTS -P -RTS@ in order to get those measurements.
 
+data-files:
+  FlameGraph/flamegraph.pl
+
 source-repository head
   type:     git
   location: https://github.com/fpco/ghc-prof-flamegraph
 
-library
-  build-depends:       base >=4 && <5
-  exposed-modules:     ProfFile
-  ghc-options:         -Wall
-  default-language:    Haskell2010
-
 executable ghc-prof-flamegraph
   main-is:             ghc-prof-flamegraph.hs
   build-depends:       base >=4.6 && <5
-                     , ghc-prof-flamegraph
+                     , filepath
                      , optparse-applicative
+                     , process
+  other-modules:       ProfFile
   default-language:    Haskell2010
   ghc-options:         -Wall


### PR DESCRIPTION
I just felt that invoking `flamegraph.pl` automatically to get pretty svg is useful.

I also opted in for bundling `flamegraph.pl` along with executable so that there's no need to install it system-wide. Do you think that is that a good idea?