### PR TITLE
Update stack & flamegraph with minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.stack-work

--- a/ghc-prof-flamegraph.cabal
+++ b/ghc-prof-flamegraph.cabal
@@ -43,5 +43,6 @@ executable ghc-prof-flamegraph
                      , optparse-applicative
                      , process
   other-modules:       ProfFile
+                     , Paths_ghc_prof_flamegraph
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,4 +2,4 @@ flags: {}
 packages:
 - '.'
 extra-deps: []
-resolver: lts-7.15
+resolver: lts-10.4


### PR DESCRIPTION
* Update stack lts to 10.4
* Update FlameGraph toa8d807a on Aug 18, 2017
* Add Paths_ghc_prof_flamegraph to other-modules in cabal file to avoid compile
  warnings
* add .gitignore for local .stack-work directory