### PR TITLE
use the system flamegraph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
+# stack
 .stack-work
+
+# cabal
+dist-newstyle
+.ghc.*
+cabal.project.local

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "FlameGraph"]
-        path = FlameGraph
-        url = https://github.com/brendangregg/FlameGraph.git

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,2 +1,0 @@
-import Distribution.Simple
-main = defaultMain

--- a/ghc-prof-flamegraph.cabal
+++ b/ghc-prof-flamegraph.cabal
@@ -29,9 +29,6 @@ description:
   bytes allocated using @--bytes@. In order to use @--bytes@ or @--ticks@ flag one
   have to run program with @+RTS -P -RTS@ in order to get those measurements.
 
-data-files:
-  FlameGraph/flamegraph.pl
-
 source-repository head
   type:     git
   location: https://github.com/fpco/ghc-prof-flamegraph
@@ -43,6 +40,5 @@ executable ghc-prof-flamegraph
                      , optparse-applicative
                      , process
   other-modules:       ProfFile
-                     , Paths_ghc_prof_flamegraph
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/ghc-prof-flamegraph.hs
+++ b/ghc-prof-flamegraph.hs
@@ -11,11 +11,9 @@ import           Data.Monoid ((<>))
 import qualified Options.Applicative as Opts
 import qualified ProfFile as Prof
 import           System.Exit (ExitCode(..), exitFailure)
-import           System.FilePath ((</>), replaceExtension)
+import           System.FilePath (replaceExtension)
 import           System.IO (stderr, stdout, hPutStrLn, hPutStr, hGetContents, IOMode(..), hClose, openFile)
 import           System.Process (proc, createProcess, CreateProcess(..), StdStream(..), waitForProcess)
-
-import Paths_ghc_prof_flamegraph (getDataDir)
 
 data Options = Options
   { optionsReportType      :: ReportType
@@ -117,9 +115,7 @@ main = do
           hPutStrLn stderr problem
           exitFailure
         Nothing      -> do
-          dataDir <- getDataDir
-          let flamegraphPath = dataDir </> "FlameGraph" </> "flamegraph.pl"
-              flamegraphProc = (proc "perl" (flamegraphPath : optionsFlamegraphFlags options))
+          let flamegraphProc = (proc "flamegraph.pl" (optionsFlamegraphFlags options))
                 { std_in  = CreatePipe
                 , std_out = CreatePipe
                 , std_err = Inherit
@@ -147,4 +143,4 @@ main = do
                 Nothing   -> pure ()
                 Just path -> putStrLn $ "Output written to " <> path
             ExitFailure{} ->
-              hPutStrLn stderr $ "Call to flamegraph.pl at " <> flamegraphPath <> " failed"
+              hPutStrLn stderr $ "Call to flamegraph.pl failed"


### PR DESCRIPTION
I completely understand if you don't want to accept this PR, as it is all about personal workflow.

`flamegraph.pl` is now becoming a popular tool to install via the system package manager, so it may not need to be bundled.

I created this PR because running `cabal new-install ghc-prof-flamegraph` built a version that froze up on any input, without using the CPU. This version uses my system `flamegraph.pl` (or anything I put into the `PATH`) and seems to work great.

With this change (and if it is released on hackage), any haskell developer can type `cabal new-install ghc-prof-flamegraph` and get a version of the tool that Just Works on their `.prof` file. They'll get an error if `flamegraph.pl` is not available, and I'm sure they can figure that out...

(I'm guessing I'll need to add flamegraph to the travis build script or CI will fail... I can look into that if you're interested in packaging it this way)